### PR TITLE
Maui port  fix application adapter modal popped

### DIFF
--- a/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
@@ -130,8 +130,9 @@ namespace Kamishibai.Maui.Tests
         public void ApplicationAdapter_ModalPopped()
         {
             var app = new Application();
+            var adapter = (ApplicationService.IApplication)new ApplicationService.ApplicationAdapter(app);
             var page1 = new ContentPage();
-            app.MainPage = page1;
+            adapter.MainPage = page1;
             ((IApplication)app).CreateWindow(null);
 
 
@@ -139,7 +140,7 @@ namespace Kamishibai.Maui.Tests
             page1.Navigation.PushModalAsync(page2);
 
             bool popped = false;
-            app.ModalPopped += (sender, args) =>
+            adapter.ModalPopped += (sender, args) =>
             {
                 popped = true;
                 Assert.NotNull(sender);

--- a/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
@@ -2,6 +2,7 @@
 using Moq;
 using Microsoft.Maui.Controls;
 using Xunit;
+using Microsoft.Maui;
 
 namespace Kamishibai.Maui.Tests
 {
@@ -128,16 +129,17 @@ namespace Kamishibai.Maui.Tests
         [Fact]
         public void ApplicationAdapter_ModalPopped()
         {
-            var mock = new ApplicationMock();
-            var adapter = (ApplicationService.IApplication)new ApplicationService.ApplicationAdapter(mock);
+            var app = new Application();
             var page1 = new ContentPage();
-            adapter.MainPage = page1;
-            
+            app.MainPage = page1;
+            ((IApplication)app).CreateWindow(null);
+
+
             var page2 = new ContentPage();
             page1.Navigation.PushModalAsync(page2);
 
             bool popped = false;
-            adapter.ModalPopped += (sender, args) =>
+            app.ModalPopped += (sender, args) =>
             {
                 popped = true;
                 Assert.NotNull(sender);


### PR DESCRIPTION
It seems that Navigation is not initialized without calling IApplication#CreateWindow, so it does not work correctly.
Please check here.
